### PR TITLE
Click on code highlights their respective breakdown

### DIFF
--- a/src/components/Framer/Posts/unsplash.js
+++ b/src/components/Framer/Posts/unsplash.js
@@ -20,7 +20,12 @@ export default class PageUnsplash extends Component {
 const content = [
   {text: "This is an introo."},
   {title: "Imports", lines: "1-2", text: "Now that we've imported. We can start by importing."},
-  {title: "Other", lines: "3-9", text: "Cool. Now that we've imported. We can start by importing."},
+  {title: "Other", lines: "4-9", text: "Cool. Now that we've imported. We can start by importing."},
+  {title: "Props", lines: "11-16", text: "PENDING. Should have a nice explanation about props..."},
+  {title: "Export class", lines: "18-18", text: "PENDING. Shoul have a nice explanation about the class..."},
+  {title: "DefaultProps", lines: "19-23", text: "PENDING. Shoul have a nice explanation about the DefaultProps..."},
+  {title: "propertyControls", lines: "25-32", text: "PENDING. Shoul have a nice explanation about propertyControls..."},
+  {title: "state", lines: "34-36", text: "PENDING. Shoul have a nice explanation about state..."},
 ];
 
 

--- a/src/components/Framer/Template/LinkedSection/style.js
+++ b/src/components/Framer/Template/LinkedSection/style.js
@@ -5,6 +5,9 @@ export const SectionWrapper = styled.div`
     margin: 8px -16px 0 -16px;
     padding: 8px 16px 16px 16px;
     border-radius: 6px;
+    &:hover {
+        cursor: pointer;
+    }
 `
 
 export const RangeBadge = styled.div`

--- a/src/components/Framer/Template/index.js
+++ b/src/components/Framer/Template/index.js
@@ -28,8 +28,24 @@ export default class Template extends Component {
     document.addEventListener("keydown", this.handleEscKey, false);
   }
 
+  componentWillMount() {
+    this.setCodeLinesState(this.props.content);
+  }
+
   componentWillUnmount(){
     document.removeEventListener("keydown", this.handleEscKey, false);
+  }
+
+  // This state helps to find the respective breakdown for each line of code
+  setCodeLinesState = (content) => {
+    let lines = content.filter(el => el.hasOwnProperty('lines'))
+    const codeLines = lines.map( el => {
+      const start = parseInt(el.lines.match(/[^-]*/i)[0]);
+      const end = parseInt(el.lines.match(/[^-]*$/i)[0]) + 1;
+      const range = _.range(start, end);
+      return range;
+    })
+    this.setState({codeLines});
   }
 
   handleEscKey = (event) => {
@@ -40,7 +56,33 @@ export default class Template extends Component {
 
   // When a section (left) is clicked, highlight it and the relevant code
   handleSectionClick = (sectionLines) => {
-    this.setState({activeLines: sectionLines})
+    this.setState({activeLines: sectionLines});
+  }
+
+  // When a line code (right) is cliked, highlight it and the relevant breakdown
+  handleCodeClick = (event) => {
+    let activeLines;
+    const { codeLines } = this.state;
+    const target = event.target
+    let wrapper = target.parentNode;
+    
+    // Go upper in the DOM if is a nested span
+    if(wrapper.tagName == 'SPAN') {
+      wrapper = wrapper.parentNode;
+    }
+
+    // Get index position from clicked element (span)
+    const index = Array.from(wrapper.children).indexOf(target.parentNode) + 1;
+    
+    // Check if it is a valid line of code was clicked
+    if(index != 0) {
+      activeLines = codeLines.find(el => { return el.includes(index); } );
+    }
+
+    // If we have a valid activeLines, then set the new State
+    if(activeLines) {
+      this.setState({activeLines});
+    }
   }
 
   // Helper function that create an array of numbers using Lodash range
@@ -149,6 +191,7 @@ export default class Template extends Component {
             }}
             lineNumberStyle={this.numberStyle}
             lineProps={this.lineProps}
+            onClick={this.handleCodeClick}
           >
             {this.props.code}
           </SyntaxHighlighter>

--- a/src/components/Framer/Template/style.js
+++ b/src/components/Framer/Template/style.js
@@ -13,6 +13,10 @@ export const Main = styled.div`
     font-size: 14px;
     color: white;
     background: rgb(29, 31, 33);
+
+    & code > span > span {
+        cursor: pointer;
+    }
 `
 
 export const Panel = styled.div`


### PR DESCRIPTION
## Implementation
- Add new state to save all the possible active lines
- Add a handler when click on a line of code
- Add cursor:pointer on hover for code > spans (right side)
- Add cursor:pointer on LinkedSelection (left side)

It's not the perfect solution but could helps as a starting point 

### Visual reference
![click-on-code-hightlights-breakdown](https://user-images.githubusercontent.com/3679836/46375978-16381100-c695-11e8-9c0f-f3801701ffb8.gif)
